### PR TITLE
Fix deepseek identifier in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ pip install -r requirements.txt
 This project uses **Llama 3.2, Deepseek 1.5, and OpenAI models**. Install them using:
 ```sh
 ollama pull llama3.2:latest
-ollama pull deepseek-r1:1.5b
+ollama pull deepseek1.5
 ```
 > ⚠️ **Note**: OpenAI models are **not** available via `ollama pull`.  
 > Instead, configure OpenAI API by setting an environment variable:


### PR DESCRIPTION
## Summary
- use the same Deepseek model name in all Ollama instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4c4052b8832b812ae6369f676057