### PR TITLE
Register LLM settings endpoints and qualify template `url_for` calls to fix BuildError

### DIFF
--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -7,6 +7,17 @@ from app.utils.file_helpers import process_file
 
 ui_blueprint = Blueprint('ui', __name__)
 
+LLM_PARAM_DEFAULTS = {
+    "CHUNK_SIZE": 250,
+    "CHUNK_OVERLAP": 120,
+    "RETRIEVER_TOP_K": 1,
+    "DEFAULT_TEMPERATURE": 0,
+    "NUM_PREDICT": 150,
+    "SIMILARITY_THRESHOLD": 0.92,
+    "MAX_CLUSTER_COUNT": 6,
+    "MAX_KEYWORDS": 3,
+}
+
 def get_ai_bot():
     from app.services.ollama_bot import get_bot
     return get_bot()
@@ -22,6 +33,20 @@ def feedback():
 @ui_blueprint.route('/chathistory')
 def chathistory():
     return render_template("chathistory.html")
+
+
+@ui_blueprint.route("/llm_settings")
+def llm_settings():
+    return render_template("llm_settings.html", **LLM_PARAM_DEFAULTS)
+
+
+@ui_blueprint.route("/update_params", methods=["POST"])
+def update_params():
+    payload = request.get_json(silent=True) or {}
+    for key in LLM_PARAM_DEFAULTS:
+        if key in payload:
+            LLM_PARAM_DEFAULTS[key] = payload[key]
+    return jsonify({"message": "Parameters updated", "params": LLM_PARAM_DEFAULTS})
 
 @ui_blueprint.route("/submit-feedback", methods=["POST"])
 def submit_feedback():

--- a/templates/chathistory.html
+++ b/templates/chathistory.html
@@ -78,7 +78,7 @@
     
     <script nonce="{{ g.nonce }}">
         document.getElementById("customizeLLMButton").addEventListener("click", function() {
-            window.location.href = "{{ url_for('llm_settings') }}";
+            window.location.href = "{{ url_for('ui.llm_settings') }}";
         });
 
         document.addEventListener("DOMContentLoaded", function() {

--- a/templates/llm_settings.html
+++ b/templates/llm_settings.html
@@ -115,7 +115,7 @@
 
     <script nonce="{{ g.nonce }}">
         document.getElementById("backToChatButton").addEventListener("click", function() {
-            window.location.href = "{{ url_for('chathistory') }}";
+            window.location.href = "{{ url_for('ui.chathistory') }}";
         });
 
         // Display live slider values

--- a/templates/semantic_search.html
+++ b/templates/semantic_search.html
@@ -14,8 +14,8 @@
         <span style="color:white; font-weight:bold;">GEO App</span>
       </div>
       <div class="navbar-links">
-        <a href="{{ url_for('index') }}">Home</a>
-        <a href="{{ url_for('semantic_search_page') }}" style="color: #f8c33c;">Semantic Search</a>
+        <a href="{{ url_for('ui.index') }}">Home</a>
+        <a href="{{ url_for('ui.semantic_search_page') }}" style="color: #f8c33c;">Semantic Search</a>
       </div>
     </div>
   </div>
@@ -44,7 +44,7 @@
     {% endif %}
 
     <div class="mt-2">
-      <a href="{{ url_for('index') }}" class="custom-button">⬅ Back to Home</a>
+      <a href="{{ url_for('ui.index') }}" class="custom-button">⬅ Back to Home</a>
     </div>
   </div>
 


### PR DESCRIPTION
### Motivation
- Templates were calling unqualified endpoint names (e.g. `llm_settings`, `chathistory`) while the app uses a `ui` blueprint, causing `werkzeug.routing.exceptions.BuildError` when building those URLs.
- The LLM settings page expected template variables that were not provided by the blueprint routes, so navigation and settings save did not function correctly.

### Description
- Added `LLM_PARAM_DEFAULTS` and two blueprint-backed routes in `app/routes/ui.py`: `GET /llm_settings` to render `llm_settings.html` with defaults and `POST /update_params` to accept updates and return the current parameters.
- Updated templates to use blueprint-qualified endpoints (`ui.llm_settings`, `ui.chathistory`, `ui.index`, `ui.semantic_search_page`) in `templates/chathistory.html`, `templates/llm_settings.html`, and `templates/semantic_search.html` to avoid `BuildError` in the modular app.
- Implemented simple in-memory parameter update logic that merges incoming JSON into `LLM_PARAM_DEFAULTS` and returns the updated parameters as JSON from `/update_params`.

### Testing
- Performed a smoke test that creates the Flask app and resolves endpoints via `url_for` inside a `test_request_context`, verifying `ui.llm_settings`, `ui.chathistory`, `ui.index`, and `ui.semantic_search_page` all resolve successfully. (Succeeded)
- No additional automated tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d914241cfc832b99831317db2a564b)