### PR TITLE
Panel-style chat output: split answers into titled panels and improve option-card styling

### DIFF
--- a/static/css/output.css
+++ b/static/css/output.css
@@ -1281,10 +1281,13 @@
 
   /* User message - Light mode */
   .user-message {
-    background-color: #d1ecf1;
-    color: black;
-    padding: 10px;
-    border-radius: 5px;
+    background-color: #cfe8ef;
+    border: 1px solid #b7d8e1;
+    color: #0f172a;
+    padding: 16px 18px;
+    border-radius: 10px;
+    font-size: 18px;
+    line-height: 1.45;
   }
 
   .question-options {
@@ -1297,23 +1300,35 @@
 
   /* AI message - Light mode */
   .ai-message {
-    background-color: #f8d7da;
-    color: black;
-    padding: 10px;
-    border-radius: 5px;
+    background-color: #f1d4da;
+    border: 1px solid #e1b6c0;
+    color: #111827;
+    padding: 16px 18px;
+    border-radius: 10px;
+    font-size: 18px;
+    line-height: 1.45;
+  }
+
+  .message-title {
+    margin-bottom: 10px;
+  }
+
+  .answer-placeholder {
+    color: #6b7280;
+    font-style: italic;
   }
 
   .response-option-list {
     display: grid;
-    gap: 8px;
-    margin-top: 6px;
+    gap: 10px;
+    margin-top: 8px;
   }
 
   .response-option-card {
-    background-color: rgba(255, 255, 255, 0.55);
-    border: 1px solid #f0b8bf;
+    background-color: rgba(255, 255, 255, 0.65);
+    border: 1px solid #e8bac2;
     border-radius: 8px;
-    padding: 8px 10px;
+    padding: 12px 14px;
   }
 
   .response-option-title {

--- a/templates/chathistory.html
+++ b/templates/chathistory.html
@@ -151,15 +151,9 @@
 
         function formatAnswerContainer(questionNumber) {
             return `
-                <div style="background-color: #f8d7da; color: #721c24; padding: 10px; 
-                            border-radius: 5px; border: 1px solid #f5c6cb; 
-                            font-weight: 500; font-size: 14px;">
-                    💡 <strong>Answer ${questionNumber}:</strong> 
-                    <span id="answerPlaceholder-${questionNumber}" 
-                        style="font-style: italic; color: grey; display: inline-block; 
-                                margin-left: 5px; animation: blink 1.5s infinite;">
-                        Processing your question...
-                    </span>
+                <div class="message-title">💡 <strong>Answer ${questionNumber}:</strong></div>
+                <div id="answerPlaceholder-${questionNumber}" class="answer-placeholder">
+                    Processing your question...
                 </div>
             `;
         }
@@ -224,7 +218,7 @@
                     const aiMessageDiv = document.createElement("div");
                     aiMessageDiv.classList.add("chat-message", "ai-message");
                     aiMessageDiv.dataset.questionNumber = tempQuestionNumber;
-                    aiMessageDiv.innerHTML = `💡 Answer ${tempQuestionNumber}: ${answer}`;
+                    aiMessageDiv.innerHTML = `💡 <strong>Answer ${tempQuestionNumber}:</strong> ${formatAssistantResponse(answer)}`;
                     answerWrapper.appendChild(aiMessageDiv);
 
                     chatMessages.appendChild(answerWrapper);
@@ -356,6 +350,7 @@
                     `;
                 }).join("");
 
+                return `<div class="response-option-list">${cards}</div>`;
             }
 
             return formatText(rawText);
@@ -525,7 +520,6 @@
                             const aiMessageDiv = document.createElement("div");
                             aiMessageDiv.classList.add("chat-message", "ai-message");
                             aiMessageDiv.dataset.questionNumber = questionNumber;
-                            aiMessageDiv.style.backgroundColor = "#f8d7da";
                             aiMessageDiv.style.padding = "10px";
                             aiMessageDiv.style.borderRadius = "5px";
                             aiMessageDiv.innerHTML = formatAnswerContainer(questionNumber);
@@ -595,7 +589,6 @@
             aiMessageDiv.classList.add("chat-message");
             const aiMessage = document.createElement("div");
             aiMessage.classList.add("ai-message");
-            aiMessage.style.backgroundColor = "#f8d7da";
             aiMessage.style.padding = "10px";
             aiMessage.style.borderRadius = "5px";
             aiMessage.innerHTML = formatAnswerContainer(questionCounter);
@@ -1519,7 +1512,6 @@
             const aiMessageDiv = document.createElement("div");
             aiMessageDiv.classList.add("chat-message", "ai-message");
             aiMessageDiv.dataset.questionNumber = questionNumber;
-            aiMessageDiv.style.backgroundColor = "#f8d7da";
             aiMessageDiv.style.padding = "10px";
             aiMessageDiv.style.borderRadius = "5px";
             aiMessageDiv.innerHTML = formatAnswerContainer(questionNumber);


### PR DESCRIPTION
### Motivation
- Visual mock showed each model output as its own panel, so answers should be split into distinct title + body blocks to allow separate panels per output. 
- Option-style responses ("Option 1:") should render as independent cards so each output section can be displayed in its own panel.

### Description
- Reworked answer rendering in `templates/chathistory.html` by changing `formatAnswerContainer` to emit a separate title row and a placeholder/body element (using `message-title` and `answer-placeholder`) for streamed content. 
- Made `formatAssistantResponse` return a `.response-option-list` of `.response-option-card` elements when `Option N:` blocks are detected so options render as independent panels. 
- Updated places that render search results and session/streamed answers to use `formatAssistantResponse` so historical and live outputs share the same panelized format. 
- Adjusted `static/css/output.css` to style `.user-message`, `.ai-message`, `.message-title`, `.answer-placeholder`, and response option cards for clearer separation and improved spacing/contrast.

### Testing
- Ran unit tests with `pytest -q` and the suite passed; `2 passed`.
- Verified no backend/API changes were made and only front-end templates/CSS were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc2004bf0832ba8aaec7f76d8df16)